### PR TITLE
Add UTF-8 scripts support, fix corrupt slotinfo handling and add support for Epsilon 24.2.1+

### DIFF
--- a/Numworks.js
+++ b/Numworks.js
@@ -376,7 +376,7 @@ class Numworks {
         }
         if (!magikFound) {
             data["magik"] = false;
-            console.warn("No usermand magic")
+            console.warn("No userland magic")
             return data
         }
 
@@ -516,7 +516,7 @@ class Numworks {
 
         const magik = 0xBADBEEEF;
         // Hack to handle corrupted slotInfo magik on old Upsilon Bootloader versions (pre 1.0.13)
-        data["slot"]["magik"] = (dv.getUint32(0x00, false) == magik) || (data["slot"]["magik"] = dv.getUint24(0x01, false) == 0xDBEEEF08);
+        data["slot"]["magik"] = (dv.getUint32(0x00, false) == magik) || ((dv.getUint32(0x00, false) & 0x00FFFFFF) == (magik & 0x00FFFFFF));
         // Check if the data is valid
         if (data["slot"]["magik"]) {
             // Check if the end magic is present

--- a/Numworks.js
+++ b/Numworks.js
@@ -679,7 +679,12 @@ class Numworks {
      */
     async __retrieveStorage(address, size) {
         this.device.startAddress = address;
-        return await this.device.do_upload(this.transferSize, size + 8);
+
+        await this.device.device_.selectAlternateInterface(this.device.intfNumber, 1);
+        let data = await this.device.do_upload(this.transferSize, size + 8);
+        await this.device.device_.selectAlternateInterface(this.device.intfNumber, 0);
+
+        return data
     }
 
     /**
@@ -690,7 +695,10 @@ class Numworks {
      */
     async __flashStorage(address, data) {
         this.device.startAddress = address;
+
+        await this.device.device_.selectAlternateInterface(this.device.intfNumber, 1);
         await this.device.do_download(this.transferSize, data, false);
+        await this.device.device_.selectAlternateInterface(this.device.intfNumber, 0);
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "upsilon.js",
-    "version": "1.4.2",
+    "version": "1.5.0",
     "description": "Utility classes to interact with a Numworks calculator using WebUSB.",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
Fix corrupt slotinfo handling:
With an old Upsilon bootloader (prior to 1.0.13), slotInfo magic was getting corrupted after suspending the calculator on Epsilon. In #9, I added a workaround for people who didn't upgrade, but it was broken (and nobody reported it until today). This pull request fix it.

Add UTF-8 scripts support:
Upsilon.js mostly supported writing UTF-8 scripts (the files just had to be NFKD encoded by the library user manually), but not reading them. I added automatic NFKD encoding on write and changed script reading to handle UTF-8 correctly. UTF-8 characters are automatically stripped on write as the OS isn't supporting it (I had corruption on Epsilon 24, but it's maybe also a bug in my testing implementation) and Upsilon.js won't parse the filename correctly if it's UTF-8-encoded
I tested this change on both Epsilon 24.1.0 N0110 with Upsilon bootloader 1.1.0 - RECOVER and Upsilon e971681.

This PR also fix Epsilon 24.2.1 and 24.3.0. In the previous state, we never set the alternate setting, and Epsilon 24.2.1 started enforcing correct alternate usage. By default, we were using `bAlternateSetting=0`, which is the Flash. Older Epsilon version didn't check weather the alternate setting was correct.
```
Found DFU: [0483:a291] ver=0115, devnum=15, cfg=1, intf=0, path="3-2", alt=1, name="@SRAM/0x20000000/01*252Ke", serial="XXXXXXXXXXXXXX"
Found DFU: [0483:a291] ver=0115, devnum=15, cfg=1, intf=0, path="3-2", alt=0, name="@Flash/0x90030000/61*064Kg,64*064Kg", serial="XXXXXXXXXXXXXX"
```